### PR TITLE
add methods to allow for iam-sso testing

### DIFF
--- a/providers/clever/clever.go
+++ b/providers/clever/clever.go
@@ -104,7 +104,7 @@ func (p *Provider) FetchUser(session goth.Session) (goth.User, error) {
 		return user, fmt.Errorf("%s cannot get user information without accessToken", p.providerName)
 	}
 
-	response, err := p.Client().Get(endpointProfile + "?access_token=" + url.QueryEscape(sess.AccessToken))
+	response, err := p.Client().Get(p.endpointProfile + "?access_token=" + url.QueryEscape(sess.AccessToken))
 	if err != nil {
 		return user, err
 	}

--- a/providers/clever/clever.go
+++ b/providers/clever/clever.go
@@ -57,6 +57,16 @@ func (p *Provider) SetName(name string) {
 	p.providerName = name
 }
 
+// SetTokenURL is to update the token URL of the provider
+func (p *Provider) SetTokenURL(tokenURL string) {
+	p.config.Endpoint.TokenURL = tokenURL
+}
+
+// SetAuthURL is to update the auth URL of the provider
+func (p *Provider) SetAuthURL(authURL string) {
+	p.config.Endpoint.AuthURL = authURL
+}
+
 // Client returns an http client.
 func (p *Provider) Client() *http.Client {
 	return goth.HTTPClientWithFallBack(p.HTTPClient)

--- a/providers/clever/clever.go
+++ b/providers/clever/clever.go
@@ -38,13 +38,14 @@ func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
 
 // Provider is the implementation of `goth.Provider` for accessing Google+.
 type Provider struct {
-	ClientKey    string
-	Secret       string
-	CallbackURL  string
-	HTTPClient   *http.Client
-	config       *oauth2.Config
-	prompt       oauth2.AuthCodeOption
-	providerName string
+	ClientKey       string
+	Secret          string
+	CallbackURL     string
+	HTTPClient      *http.Client
+	config          *oauth2.Config
+	prompt          oauth2.AuthCodeOption
+	providerName    string
+	endpointProfile string
 }
 
 // Name is the name used to retrieve this provider later.
@@ -62,9 +63,9 @@ func (p *Provider) SetTokenURL(tokenURL string) {
 	p.config.Endpoint.TokenURL = tokenURL
 }
 
-// SetAuthURL is to update the auth URL of the provider
-func (p *Provider) SetAuthURL(authURL string) {
-	p.config.Endpoint.AuthURL = authURL
+// SetEndpointProfile is to update the endpoint profile URL of the provider
+func (p *Provider) SetEndpointProfile(endpointProfile string) {
+	p.endpointProfile = endpointProfile
 }
 
 // Client returns an http client.

--- a/providers/clever/clever.go
+++ b/providers/clever/clever.go
@@ -33,6 +33,7 @@ func New(clientKey, secret, callbackURL string, scopes ...string) *Provider {
 		providerName: "clever",
 	}
 	p.config = newConfig(p, scopes)
+	p.endpointProfile = endpointProfile
 	return p
 }
 


### PR DESCRIPTION
TokenURL and EndpointProfile are currently hard coded values in the clever provider. If we want to be able to switch those 2 URL's out for the mock API, we will need the ability to override the hard coded values. So for this PR, I added TokenURL and EndpointProfile to the provider (rather than be hard coded), added 2 setters to override those values, and then used the provider endpoints instead of the hard coded values.